### PR TITLE
Vert channel

### DIFF
--- a/vr1/VR1facility.py
+++ b/vr1/VR1facility.py
@@ -18,7 +18,7 @@ class Facility:
         if lattice is not None:
             lattice = lattice.model
 
-        self.cells["core.1"]    = openmc.Cell(name="core.1",    fill = lattice,             region=-self.surfaces["CORE.rec"] & +self.surfaces['RCcy.1'] & -self.surfaces["FAZ.2"] & +self.surfaces["GRD.zd"])
+        self.cells["core.1"]    = openmc.Cell(name="core.1",    fill = lattice,                      region=-self.surfaces["CORE.rec"] & +self.surfaces['RCcy.1'] & -self.surfaces["FAZ.2"] & +self.surfaces["H01.sc"])
         self.cells["surf.1"]    = openmc.Cell(name="surf.1",    fill = self.materials.radialchannel, region=-self.surfaces["RCcy.1"] & +self.surfaces["RCcy.2"] & +self.surfaces["RCpy.2"])
         self.cells["water.1"]   = openmc.Cell(name="water.1",   fill = self.materials.water,         region=-self.surfaces["H01.1"] & +self.surfaces["RCcy.1"] & +self.surfaces["RCpy.1"] & -self.surfaces["H01.zt"] & +self.surfaces["H01.zd"] & ~self.cells["core.1"].region)
         self.cells["water.2"]   = openmc.Cell(name="water.2",   fill = self.materials.water,         region=-self.surfaces["H01.1"] & -self.surfaces["RCpy.1"] & +self.surfaces["RCpy.4"] & +self.surfaces["RCcy.10"] & -self.surfaces["H01.zt"] & +self.surfaces["H01.zd"])

--- a/vr1/core.py
+++ b/vr1/core.py
@@ -75,7 +75,7 @@ class TestLattice(VR1core):
             lattice_array.append(_l)
         self.lattice.universes = lattice_array
         """ Lattice box """
-        z0: float = plane_zs['FAZ.5']
+        z0: float = plane_zs['H01.sc']
         z1: float = plane_zs['FAZ.2']
         lattice_box = openmc.model.RectangularParallelepiped(-xy_corner, xy_corner, -xy_corner, xy_corner, z0, z1)
         lattice_cell = openmc.Cell(fill=self.lattice, region=-lattice_box)

--- a/vr1/lattice_units.py
+++ b/vr1/lattice_units.py
@@ -325,8 +325,12 @@ class GridPlate:
         return openmc.Universe(name=f'grid_plate_unit', cells=list(self.cells.values()))
 
 class Water(LatticeUnitVR1):
-    """ Water lattice unit """
-    def __init__(self, materials: VR1Materials):
+    """ 
+    Water lattice unit 
+    RC variable = radial channel. if location is at radial_channel, return a straight water column with no grid plate
+    """
+    def __init__(self, materials: VR1Materials,RC=False):
+        self.RC = RC
         super().__init__(materials)
 
     def name(self) -> str:
@@ -334,6 +338,9 @@ class Water(LatticeUnitVR1):
 
     def build(self) -> openmc.Universe:
         surfaces['boundary_XY'] = openmc.model.RectangularPrism(width=lattice_wh, height=lattice_wh)
+        if self.RC is True: 
+            water_RC = openmc.Cell(name='water_(RC)',fill=self.materials.water,region=-surfaces['boundary_XY'])
+            return openmc.Universe(name='water_(radial_channel)',cells=[water_RC])
         self.cells['water1'] = openmc.Cell(name='water1', fill=self.materials.water, region=-surfaces['boundary_XY'] & +surfaces['GRD.zt'])
         self.cells['water2'] = openmc.Cell(name='water2', fill=self.materials.water, region=-surfaces['boundary_XY'] & +surfaces['1FT.1'] & -surfaces['GRD.zt'])
 
@@ -343,6 +350,47 @@ class Water(LatticeUnitVR1):
 
         return openmc.Universe(name='water', cells=list(self.cells.values()))
 
+class VertChannel(LatticeUnitVR1):
+    """ Water lattice unit """
+    def __init__(self, materials: VR1Materials,diameter:int = 56):
+        self.diameter=diameter
+        super().__init__(materials)
+
+    def name(self) -> str:
+        return "Water filling the lattice"
+
+    def build(self) -> openmc.Universe:
+        """
+        Three diameters of vertical channel available: 90mm, 56mm, 30mm, 25mm, 12mm
+        """
+        surfaces['boundary_XY']  = openmc.model.RectangularPrism(width=lattice_wh, height=lattice_wh)
+
+        if self.diameter not in [1.2,2.5,3.0,5.6,9.0]:
+            raise ValueError(f'No vertical channels with diameter {self.diameter*10}mm are available.\nThe possible diameters are 90mm, 56mm, 30mm, 25mm, and 12mm.')
+        if self.diameter in [1.2,2.5,3.0]:
+            #small channel, this one is way harder to code bc the channel goes through the grid plate ? or something
+            surfaces['inner_radius'] = openmc.ZCylinder(r=self.diameter/2)
+            surfaces['outer_radius'] = openmc.ZCylinder(r=self.diameter/2+0.1)
+            surfaces['channel_bottom'] = openmc.ZPlane(z0=-10)
+        else:
+            #big channel
+            surfaces['inner_radius'] = openmc.ZCylinder(r=self.diameter/2)
+            surfaces['outer_radius'] = openmc.ZCylinder(r=self.diameter/2+0.5)
+
+            surfaces['channel_bottom'] = openmc.ZPlane(z0=0)
+            surfaces['channel_bottom_inner'] = openmc.ZPlane(z0=0.5) #thickness of pipe is 0.5 radially so i'm assuming it is the same here
+
+            self.cells['water1'] =    openmc.Cell(name='water1', fill=self.materials.water, region=-surfaces['boundary_XY'] & +surfaces['outer_radius'] & +surfaces['GRD.zt'])
+            self.cells['water2'] =    openmc.Cell(name='water2', fill=self.materials.water, region=-surfaces['boundary_XY'] & +surfaces['1FT.1'] & -surfaces['GRD.zt'])
+
+            self.cells['channel'] =     openmc.Cell(name='channel',     fill=self.materials.bigchannel,region=-surfaces['outer_radius'] & +surfaces['inner_radius'] & +surfaces['channel_bottom'])
+            self.cells['channel_head'] = openmc.Cell(name='channel_head', fill=self.materials.bigchannel,region=-surfaces['inner_radius'] & +surfaces['channel_bottom'] & -surfaces['channel_bottom_inner'])
+            self.cells['channel_air'] = openmc.Cell(name='channel_air', fill=self.materials.air,region=-surfaces['inner_radius'] & +surfaces['channel_bottom_inner'])
+
+            gridplate = GridPlate(self.materials)
+            grid_unit = gridplate.build()
+            self.cells['grid'] = openmc.Cell(name='grid',fill=grid_unit,region=-surfaces['1FT.1'] & -surfaces['FAZ.4'])
+            return openmc.Universe(name='big_channel', cells=list(self.cells.values()))
 
 class IRT4M(LatticeUnitVR1):
     """ Class that returns IRT4M fuel units """

--- a/vr1/lattice_units.py
+++ b/vr1/lattice_units.py
@@ -191,6 +191,7 @@ plane_zs: dict = {
     "Gpz.6": -3.5,      # bottom end in grid
     "GRD.zt": 0,        # upper edge of core grid
     "GRD.zd": -7.51,    # lower edge of core grid
+    "H01.sc": -10.0     # small channel insertion
 }
 
 # ALL SURFACES ARE HERE
@@ -322,6 +323,7 @@ class GridPlate:
         self.cells['water_low_NE'] = openmc.Cell(name='water_bot_NE', fill=self.materials.water,region=+surfaces['GRD.1'] & -surfaces['boundary_XY'] & +surfaces['GRD.yp'] & +surfaces['GRD.xp'] & -surfaces['GRD.zt'])
         self.cells['water_low_SW'] = openmc.Cell(name='water_bot_SW', fill=self.materials.water,region=+surfaces['GRD.1'] & -surfaces['boundary_XY'] & -surfaces['GRD.yp'] & -surfaces['GRD.xp'] & -surfaces['GRD.zt'])
         self.cells['water_low_SE'] = openmc.Cell(name='water_bot_SE', fill=self.materials.water,region=+surfaces['GRD.1'] & -surfaces['boundary_XY'] & -surfaces['GRD.yp'] & +surfaces['GRD.xp'] & -surfaces['GRD.zt'])
+        self.cells['water_low_low'] = openmc.Cell(name='water_low_low', fill=self.materials.water,region=-self.surfaces['boundary_XY'] & -self.surfaces['GRD.zd'])
         return openmc.Universe(name=f'grid_plate_unit', cells=list(self.cells.values()))
 
 class Water(LatticeUnitVR1):
@@ -392,7 +394,7 @@ class VertChannel(LatticeUnitVR1):
             self.cells['grid'] = openmc.Cell(name='grid',fill=grid_unit,region=-surfaces['1FT.1'] & -surfaces['FAZ.4'])
             return openmc.Universe(name='big_channel', cells=list(self.cells.values()))
 
-class IRT4M(LatticeUnitVR1):
+class IRT4M(LatticeUnitVR1_local):
     """ Class that returns IRT4M fuel units """
     def __init__(self, materials: VR1Materials, fa_type: str, boundary: str = 'water') -> None:
         super().__init__(materials)


### PR DESCRIPTION
Added in vertical channels of diameters 90, 56, 30, 25, and 12mm. These are tubes of air that extend to the grid plate, and in the case of the three smallest diameters will persist past the grid plate to z=-10. This is significant as it required recoding the location of the entire lattice insertion with the addition of the new ZPlane "H01.sc". 
Notably, the 90mm vertical channel is too large for the lattice cell size, but it is present in the SERPENT file so I just kept it in