### PR TITLE
removed dependency for openmc because it causes the package install t…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
         'json5',
         'pytest',
         'scipy',
-        'openmc',
+        # 'openmc',
         'matplotlib~=3.9',
         'uncertainties',
         'setuptools',


### PR DESCRIPTION
…o fail if you installed openmc with conda