### PR TITLE
Vert channel

### DIFF
--- a/vr1/core.py
+++ b/vr1/core.py
@@ -2,7 +2,7 @@
 import openmc
 from vr1.materials import VR1Materials, vr1_materials
 from vr1.lattice_units import (rects, plane_zs, lattice_unit_names, lattice_lower_left, lattice_upper_right,
-                               IRT4M, lattice_pitch, LatticeUnitVR1)
+                               IRT4M, lattice_pitch, LatticeUnitVR1, AbsRod)
 
 # Write an FA lattice, or the core lattice, or the whole reactor
 core_types: list[str] = ['fuel_lattice', 'active_zone', 'reactor']
@@ -134,6 +134,10 @@ class TestLattice(VR1core):
         for i in range(n):
             _l: list[openmc.UniverseBase] = []
             for j in range(n):
+                # if '_' in lattice_str[i][j]:
+                #     height = lattice_str[i][j][2:]
+                #     assembly = AbsRod(materials=vr1_materials,assembly_type='6',rod_height=float(height))
+                #     _l.append(lattice_builder.get(assembly.build()))
                 _l.append(lattice_builder.get(lattice_str[i][j]))
             lattice_array.append(_l)
 

--- a/vr1/lattice_units.py
+++ b/vr1/lattice_units.py
@@ -277,7 +277,8 @@ class LatticeUnitVR1:
             'v90': VertChannel(materials=self.materials,diameter=90),
             'v56': VertChannel(materials=self.materials,diameter=56),
             'v30': VertChannel(materials=self.materials,diameter=30),
-            'v25': VertChannel(materials=self.materials,diameter=25),
+            # 'v25': VertChannel(materials=self.materials,diameter=25),
+            'v25': IRT4M(materials=self.materials,fa_type='6',VC_diameter=25),
             'v12': VertChannel(materials=self.materials,diameter=12),
             'O': IRT4M(materials=self.materials,fa_type='6',abs_rod_height=84.7), #fully removed control rod
             'X': IRT4M(materials=self.materials,fa_type='6',abs_rod_height=0), #fully inserted control rod
@@ -509,7 +510,7 @@ class VertChannel(LatticeUnitVR1):
 
 class IRT4M(LatticeUnitVR1):
     """ Class that returns IRT4M fuel units """
-    def __init__(self, materials: VR1Materials, fa_type: str, abs_rod_height = None, boundary: str = 'water') -> None:
+    def __init__(self, materials: VR1Materials, fa_type: str, abs_rod_height = None, VC_diameter = None, boundary: str = 'water') -> None:
         """Initialize the object with specific materials, fuel assembly type, and optional parameters.
         Parameters:
             - materials (VR1Materials): Materials used in the VR1 reactor.
@@ -520,6 +521,7 @@ class IRT4M(LatticeUnitVR1):
             - None: This is an initializer and does not return a value."""
         super().__init__(materials)
         self.abs_rod_height = abs_rod_height
+        self.VC_diameter = VC_diameter
         if boundary not in lattice_unit_boundaries:
             raise ValueError(f'boundary {boundary} is not valid')
         self.boundary: str = boundary
@@ -546,25 +548,37 @@ class IRT4M(LatticeUnitVR1):
 
         """ Common FA cells """
 
+
+        
+        surfaces['centerline'] = surfaces[f'{self.n_plates}FT.4']
+        
+        gridplate = GridPlate(self.materials)
+        grid_unit = gridplate.build()
+        self.cells['grid'] = openmc.Cell(name='grid',fill=grid_unit,region=-surfaces['1FT.1'] & -surfaces['GRD.zt'])
+        
         if self.abs_rod_height is not None:
-            return self.build_abs()
+            # return self.build_abs()
+            surfaces['centerline'] = surfaces['ABS.1']
+            self.cells['grid'] = openmc.Cell(name='grid',fill=grid_unit,region=-surfaces['1FT.1'] & -surfaces['GRD.zt'] & +surfaces['centerline'])
         if self.VC_diameter is not None:
-            self.build_VC()
+            # self.build_VC()
+            surfaces['centerline'] = surfaces[f'C{self.VC_diameter}.1']
+            self.cells['grid'] = openmc.Cell(name='grid',fill=grid_unit,region=-surfaces['1FT.1'] & -surfaces['GRD.zt'] & +surfaces['centerline'])
             
         self.cells['out_top'] = openmc.Cell(name='out_top', fill=self.materials.water, region=-surfaces['boundary_XY'] & +surfaces['1FT.1'] & -surfaces['FAZ.2'] & +surfaces['FAZ.3'])
         self.cells['out_mid'] = openmc.Cell(name='out_mid', fill=self.materials.water, region=-surfaces['boundary_XY'] & +surfaces['1FT.1'] & -surfaces['FAZ.3'] & +surfaces['FAZ.4'])
         self.cells['out_bot'] = openmc.Cell(name='out_bot', fill=self.materials.water, region=-surfaces['boundary_XY'] & +surfaces['1FT.1'] & -surfaces['FAZ.4'])
         for i in range(1, self.n_plates):
             self.cells[f'top_c_{i}'] = openmc.Cell(name=f'top_c_{i}', fill=self.materials.cladding, region=-surfaces[f'{i}FT.1'] & +surfaces[f'{i}FT.4'] & -surfaces['FAZ.2'] & +surfaces['FAZ.3'])
-            self.cells[f'top_w_{i}'] = openmc.Cell(name=f'top_w_{i}', fill=self.materials.water, region=-surfaces[f'{i}FT.4'] & +surfaces[f'{i + 1}FT.1'] & -surfaces['FAZ.2'] & +surfaces['FAZ.3'])
+            self.cells[f'top_w_{i}'] = openmc.Cell(name=f'top_w_{i}', fill=self.materials.water, region=-surfaces[f'{i}FT.4'] & +surfaces['centerline'] & -surfaces['FAZ.2'] & +surfaces['FAZ.3'])
 
             self.cells[f'mid_c_{i}'] = openmc.Cell(name=f'mid_c_{i}', fill=self.materials.cladding, region=-surfaces[f'{i}FT.1'] & +surfaces[f'{i}FT.2'] & -surfaces['FAZ.3'] & +surfaces['FAZ.4'])
             self.cells[f'mid_f_{i}'] = openmc.Cell(name=f'mid_f_{i}', fill=self.materials.fuel, region=-surfaces[f'{i}FT.2'] & +surfaces[f'{i}FT.3'] & -surfaces['FAZ.3'] & +surfaces['FAZ.4'])
             self.cells[f'mid_i_{i}'] = openmc.Cell(name=f'mid_i_{i}', fill=self.materials.cladding, region=-surfaces[f'{i}FT.3'] & +surfaces[f'{i}FT.4'] & -surfaces['FAZ.3'] & +surfaces['FAZ.4'])
-            self.cells[f'mid_w_{i}'] = openmc.Cell(name=f'mid_w_{i}', fill=self.materials.water, region=-surfaces[f'{i}FT.4'] & +surfaces[f'{i + 1}FT.1'] & -surfaces['FAZ.3'] & +surfaces['FAZ.4'])
+            self.cells[f'mid_w_{i}'] = openmc.Cell(name=f'mid_w_{i}', fill=self.materials.water, region=-surfaces[f'{i}FT.4'] & +surfaces['centerline'] & -surfaces['FAZ.3'] & +surfaces['FAZ.4'])
 
             self.cells[f'bot_c_{i}'] = openmc.Cell(name=f'bot_c_{i}', fill=self.materials.cladding, region=-surfaces[f'{i}FT.1'] & +surfaces[f'{i}FT.4'] & -surfaces['FAZ.4'] & +surfaces['FAZ.5'])
-            self.cells[f'bot_w_{i}'] = openmc.Cell(name=f'bot_w_{i}', fill=self.materials.water, region=-surfaces[f'{i}FT.4'] & +surfaces[f'{i + 1}FT.1'] & -surfaces['FAZ.4'] & +surfaces['FAZ.5'])
+            self.cells[f'bot_w_{i}'] = openmc.Cell(name=f'bot_w_{i}', fill=self.materials.water, region=-surfaces[f'{i}FT.4'] & +surfaces['centerline'] & -surfaces['FAZ.4'] & +surfaces['FAZ.5'])
 
         i = self.n_plates
         self.cells[f'top_c_{i}'] = openmc.Cell(name=f'top_c_{i}', fill=self.materials.cladding, region=-surfaces[f'{i}FT.1'] & +surfaces[f'{i}FT.4'] & -surfaces['FAZ.2'] & +surfaces['FAZ.3'])
@@ -579,6 +593,17 @@ class IRT4M(LatticeUnitVR1):
         self.cells[f'bot_w_{i}'] = openmc.Cell(name=f'bot_w_{i}', fill=self.materials.water, region=-surfaces[f'{i}FT.4'] & -surfaces['FAZ.4'] & +surfaces['FAZ.5'])
 
         self.cells[f'0.8.60']    = openmc.Cell(name=f'0.8.60', fill=self.materials.water,   region=-surfaces['1FT.1'] & -surfaces['ELE.1'] & -surfaces['FAZ.4'] & +surfaces['FAZ.5'])
+
+        for j in range(1,self.n_plates):
+            self.cells[f'{j}hold_1'] = openmc.Cell(name=f'{j}hold_1', fill=self.materials.cladding,region=-surfaces[f'{j}FT.1'] & +surfaces[f'{j}FT.4'] & -surfaces['FAZ.4'] & +surfaces['FAZ.5'])
+            self.cells[f'{j}hold_2'] = openmc.Cell(name=f'{j}hold_2', fill=self.materials.water,   region=-surfaces[f'{j}FT.4'] & +surfaces[f'{j+1}FT.1'] & -surfaces['FAZ.4'] & +surfaces['FAZ.5'])
+        
+        j=self.n_plates
+        self.cells[f'{j}hold_final1'] = openmc.Cell(name=f'{j}hold_1', fill=self.materials.cladding,region=-surfaces[f'{j}FT.1'] & +surfaces[f'{j}FT.4'] & -surfaces['FAZ.4'] & +surfaces['FAZ.5'])
+        
+        
+        self.cells[f'{j}hold_final2'] = openmc.Cell(name=f'{j}hold_2', fill=self.materials.water,   region=-surfaces[f'{j}FT.4'] & +surfaces['centerline'] & -surfaces['FAZ.4'] & +surfaces['FAZ.5'])
+        
         self.cells[f'0.8.61']    = openmc.Cell(name=f'0.8.61', fill=self.materials.cladding,region=-surfaces['1FT.1'] & +surfaces['1FT.4'] & -surfaces['FAZ.4'] & +surfaces['FAZ.5'])
         self.cells[f'0.8.62']    = openmc.Cell(name=f'0.8.62', fill=self.materials.water,   region=-surfaces['1FT.4'] & +surfaces['2FT.1'] & -surfaces['FAZ.4'] & +surfaces['FAZ.5'])
         self.cells[f'0.8.63']    = openmc.Cell(name=f'0.8.63', fill=self.materials.cladding,region=-surfaces['2FT.1'] & +surfaces['2FT.4'] & -surfaces['FAZ.4'] & +surfaces['FAZ.5'])
@@ -600,9 +625,7 @@ class IRT4M(LatticeUnitVR1):
         self.cells[f'0.8.79']    = openmc.Cell(name=f'0.8.79', fill=self.materials.cladding,region=-surfaces['1FT.1'] & +surfaces['1FT.4'] & -surfaces['FAZ.5'] & +surfaces['GRD.zt'])
         self.cells[f'0.8.80']    = openmc.Cell(name=f'0.8.80', fill=self.materials.water,   region=-surfaces['1FT.4'] & -surfaces['FAZ.5'] & +surfaces['GRD.zt'])
 
-        gridplate = GridPlate(self.materials)
-        grid_unit = gridplate.build()
-        self.cells['grid'] = openmc.Cell(name='grid',fill=grid_unit,region=-surfaces['1FT.1'] & -surfaces['GRD.zt'])
+
 
         return openmc.Universe(name=f'lattice_{lattice_unit_names[self.fa_type]}', cells=list(self.cells.values()))
 
@@ -788,7 +811,7 @@ class AbsRod(LatticeUnitVR1):
         cell_0Absrod_2 = openmc.Cell(name='Absrod2', fill=self.materials.cdlayer,   region=-surfaces['ABS.4'] & +surfaces['ABS.5']  & +lower_bound_head)
         cell_0Absrod_3 = openmc.Cell(name='Absrod3', fill=self.materials.abscenter, region=-surfaces['ABS.5'] & +lower_bound_head)
         cell_0Absrod_4 = openmc.Cell(name='Absrod4', fill=self.materials.abshead,   region=-surfaces['ABS.3'] & -lower_bound_head & +lower_bound_abs)
-
+        cell_0Absrod_5 = openmc.Cell(name='Absrod_damp', fill=self.materials.damper,region=-surfaces['GRD.2'] & +surfaces['DMP.1'] +surfaces['GRD.zd'] & +surfaces['ABS.3'])
         self.cells['Plenum'] = openmc.Cell(name='Plenum', fill=self.materials.water, region=-surfaces['ABS.3'] & -lower_bound_abs & +surfaces['GRD.zd'])
 
         universe_0Absrod = openmc.Universe(cells=[cell_0Absrod_1, cell_0Absrod_2, cell_0Absrod_3, cell_0Absrod_4])


### PR DESCRIPTION
Added in vertical channel and absorption rod capabilities into fuel assemblies. They have been completely coded and, in some cases, their regions redefined. This has fixed that strange bug listed from here https://github.com/ondrejch/VR1-openmc/issues/23. 

Now, instead of specifying the assembly type and then the rod height, you instead initialize the absorption rod (or vertical channel) as its own unit and then say whether or not you want it inside of an assembly. While it's less intuitive, it does make the coding far simpler.